### PR TITLE
feat: more helper functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: format
 format:
-	poetry run ruff check .
+	poetry run ruff check --fix .
 	poetry run black .
 
 .PHONY: pytest

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ Checking revocation using an already loaded cryptography [x509.Certificate](http
 
 ```python3
 from cryptography import x509
-from pki_tools.ocsp import check_revoked_crypto_cert, Revoked, Error
+from pki_tools.ocsp import check_revoked, Revoked, Error
 
 cert : x509.Certificate = ...
 issuer: x509.Certificate = ...
 
 try:
-    check_revoked_crypto_cert(cert, issuer)
+    check_revoked(cert, issuer)
 except Revoked as e:
     print(f"Certificate revoked: {e}")
 except Error as e:
@@ -88,13 +88,13 @@ Checking revocation using an already loaded cryptography [x509.Certificate](http
 
 ```python3
 from cryptography import x509
-from pki_tools.ocsp import check_revoked_crypto_cert, Revoked, Error
+from pki_tools.ocsp import check_revoked, Revoked, Error
 
 cert : x509.Certificate = ...
 issuer_cert : x509.Certificate = ...
 
 try:
-    check_revoked_crypto_cert(cert, issuer_cert)
+    check_revoked(cert, issuer_cert)
 except Revoked as e:
     print(f"Certificate revoked: {e}")
 except Error as e:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ PKI tools exposes a high level `cryptography` API for e.g.:
 
 Checking revocation using PEM encoded certificate
 ```python3
-from pki_tools.crl import check_revoked, Revoked, Error
+from pki_tools.crl import is_revoked, Revoked, Error
 
 cert_pem = """
 -----BEGIN CERTIFICATE-----
@@ -31,7 +31,7 @@ cert_pem = """
 """
 
 try:
-    check_revoked(cert_pem)
+    is_revoked(cert_pem)
 except Revoked as e:
     print(f"Certificate revoked: {e}")
 except Error as e:
@@ -43,13 +43,13 @@ Checking revocation using an already loaded cryptography [x509.Certificate](http
 
 ```python3
 from cryptography import x509
-from pki_tools.ocsp import check_revoked, Revoked, Error
+from pki_tools.ocsp import is_revoked, Revoked, Error
 
 cert : x509.Certificate = ...
 issuer: x509.Certificate = ...
 
 try:
-    check_revoked(cert, issuer)
+    is_revoked(cert, issuer)
 except Revoked as e:
     print(f"Certificate revoked: {e}")
 except Error as e:
@@ -61,7 +61,7 @@ except Error as e:
 
 Checking revocation using PEM encoded certificate
 ```python3
-from pki_tools.ocsp import check_revoked, Revoked, Error
+from pki_tools.ocsp import is_revoked, Revoked, Error
 
 cert_pem = """
 -----BEGIN CERTIFICATE-----
@@ -76,7 +76,7 @@ issuer_pem = """
 """
 
 try:
-    check_revoked(cert_pem, issuer_pem)
+    is_revoked(cert_pem, issuer_pem)
 except Revoked as e:
     print(f"Certificate revoked: {e}")
 except Error as e:
@@ -88,13 +88,13 @@ Checking revocation using an already loaded cryptography [x509.Certificate](http
 
 ```python3
 from cryptography import x509
-from pki_tools.ocsp import check_revoked, Revoked, Error
+from pki_tools.ocsp import is_revoked, Revoked, Error
 
 cert : x509.Certificate = ...
 issuer_cert : x509.Certificate = ...
 
 try:
-    check_revoked(cert, issuer_cert)
+    is_revoked(cert, issuer_cert)
 except Revoked as e:
     print(f"Certificate revoked: {e}")
 except Error as e:

--- a/pki_tools/crl.py
+++ b/pki_tools/crl.py
@@ -37,6 +37,7 @@ def is_revoked(cert: x509.Certificate) -> bool:
                     return True
     except ExtensionNotFound:
         raise exceptions.ExtensionMissing()
+    return False
 
 
 def _get_crl_from_url(crl_url):

--- a/pki_tools/crl.py
+++ b/pki_tools/crl.py
@@ -7,20 +7,12 @@ from pki_tools import exceptions
 from pki_tools import utils
 
 
-class CrlFetchFailure(exceptions.Error):
-    pass
-
-
-class CrlLoadError(exceptions.Error):
-    pass
-
-
-def check_revoked(cert_pem: str):
+def check_revoked_pem(cert_pem: str):
     cert = utils.cert_from_pem(cert_pem)
-    check_revoked_crypto_cert(cert)
+    check_revoked(cert)
 
 
-def check_revoked_crypto_cert(cert: x509.Certificate):
+def check_revoked(cert: x509.Certificate):
     ext = cert.extensions
     try:
         crl_ex = ext.get_extension_for_oid(
@@ -50,7 +42,7 @@ def _get_crl_from_url(crl_url):
     ret = requests.get(crl_url)
 
     if ret.status_code != 200:
-        raise CrlFetchFailure
+        raise exceptions.CrlFetchFailure
 
     crl_data = ret.content
     return _crl_data_to_crypto(crl_data)
@@ -65,4 +57,4 @@ def _crl_data_to_crypto(crl_data):
     try:
         return x509.load_pem_x509_crl(crl_data)
     except TypeError as e:
-        raise CrlLoadError(e) from None
+        raise exceptions.CrlLoadError(e) from None

--- a/pki_tools/crl.py
+++ b/pki_tools/crl.py
@@ -3,20 +3,20 @@ from cryptography import x509
 from cryptography.x509.extensions import ExtensionNotFound
 from cryptography.x509.oid import ExtensionOID
 
-from pki_tools.exceptions import Error, ExtensionMissing, Revoked
-from pki_tools.utils import cert_from_pem
+from pki_tools import exceptions
+from pki_tools import utils
 
 
-class CrlFetchFailure(Error):
+class CrlFetchFailure(exceptions.Error):
     pass
 
 
-class CrlLoadError(Error):
+class CrlLoadError(exceptions.Error):
     pass
 
 
 def check_revoked(cert_pem: str):
-    cert = cert_from_pem(cert_pem)
+    cert = utils.cert_from_pem(cert_pem)
     check_revoked_crypto_cert(cert)
 
 
@@ -41,9 +41,9 @@ def check_revoked_crypto_cert(cert: x509.Certificate):
                         f"Certificate with serial: {cert.serial_number} "
                         f"is revoked since: {r.revocation_date}"
                     )
-                    raise Revoked(err)
+                    raise exceptions.Revoked(err)
     except ExtensionNotFound:
-        raise ExtensionMissing()
+        raise exceptions.ExtensionMissing()
 
 
 def _get_crl_from_url(crl_url):

--- a/pki_tools/exceptions.py
+++ b/pki_tools/exceptions.py
@@ -12,3 +12,15 @@ class Revoked(Error):
 
 class CertLoadError(Error):
     pass
+
+
+class OcspFetchFailure(Error):
+    pass
+
+
+class CrlFetchFailure(Error):
+    pass
+
+
+class CrlLoadError(Error):
+    pass

--- a/pki_tools/exceptions.py
+++ b/pki_tools/exceptions.py
@@ -6,10 +6,6 @@ class ExtensionMissing(Error):
     pass
 
 
-class Revoked(Error):
-    pass
-
-
 class CertLoadError(Error):
     pass
 

--- a/pki_tools/ocsp.py
+++ b/pki_tools/ocsp.py
@@ -17,19 +17,13 @@ from pki_tools import exceptions
 from pki_tools import utils
 
 
-class OcspFetchFailure(exceptions.Error):
-    pass
-
-
-def check_revoked(cert_pem: str, issuer_cert_pem: str):
+def check_revoked_pem(cert_pem: str, issuer_cert_pem: str):
     cert = utils.cert_from_pem(cert_pem)
     issuer_cert = utils.cert_from_pem(issuer_cert_pem)
-    check_revoked_crypto_cert(cert, issuer_cert)
+    check_revoked(cert, issuer_cert)
 
 
-def check_revoked_crypto_cert(
-    cert: x509.Certificate, issuer_cert: x509.Certificate
-):
+def check_revoked(cert: x509.Certificate, issuer_cert: x509.Certificate):
     builder = ocsp.OCSPRequestBuilder()
     builder = builder.add_certificate(cert, issuer_cert, SHA256())
     req = builder.build()
@@ -61,13 +55,13 @@ def _get_ocsp_status(uri) -> OCSPResponse:
     ret = requests.get(uri)
 
     if ret.status_code != 200:
-        raise OcspFetchFailure(
+        raise exceptions.OcspFetchFailure(
             f"Unexpected response status code: {ret.status_code}"
         )
 
     ocsp_res = ocsp.load_der_ocsp_response(ret.content)
     if ocsp_res.response_status != OCSPResponseStatus.SUCCESSFUL:
-        raise OcspFetchFailure(
+        raise exceptions.OcspFetchFailure(
             f"Invalid OCSP Response status: {ocsp_res.response_status}"
         )
 

--- a/pki_tools/ocsp.py
+++ b/pki_tools/ocsp.py
@@ -24,9 +24,7 @@ def is_revoked_pem(cert_pem: str, issuer_cert_pem: str) -> bool:
     return is_revoked(cert, issuer_cert)
 
 
-def is_revoked(
-    cert: x509.Certificate, issuer_cert: x509.Certificate
-) -> bool:
+def is_revoked(cert: x509.Certificate, issuer_cert: x509.Certificate) -> bool:
     builder = ocsp.OCSPRequestBuilder()
     builder = builder.add_certificate(cert, issuer_cert, SHA256())
     req = builder.build()

--- a/pki_tools/ocsp.py
+++ b/pki_tools/ocsp.py
@@ -13,17 +13,17 @@ from cryptography.x509.ocsp import (
 )
 from cryptography.x509.oid import ExtensionOID
 
-from pki_tools.exceptions import Error, ExtensionMissing, Revoked
-from pki_tools.utils import cert_from_pem
+from pki_tools import exceptions
+from pki_tools import utils
 
 
-class OcspFetchFailure(Error):
+class OcspFetchFailure(exceptions.Error):
     pass
 
 
 def check_revoked(cert_pem: str, issuer_cert_pem: str):
-    cert = cert_from_pem(cert_pem)
-    issuer_cert = cert_from_pem(issuer_cert_pem)
+    cert = utils.cert_from_pem(cert_pem)
+    issuer_cert = utils.cert_from_pem(issuer_cert_pem)
     check_revoked_crypto_cert(cert, issuer_cert)
 
 
@@ -52,9 +52,9 @@ def check_revoked_crypto_cert(
                         f"Certificate with serial: {cert.serial_number} "
                         f"is revoked since: {ocsp_res.revocation_time}"
                     )
-                    raise Revoked(err)
+                    raise exceptions.Revoked(err)
     except ExtensionNotFound:
-        raise ExtensionMissing()
+        raise exceptions.ExtensionMissing()
 
 
 def _get_ocsp_status(uri) -> OCSPResponse:

--- a/pki_tools/utils.py
+++ b/pki_tools/utils.py
@@ -23,7 +23,9 @@ def check_revoked(cert_pem: str, issuer_cert_pem: str = None):
     check_revoked_crypto_cert(cert, issuer_cert)
 
 
-def check_revoked_crypto_cert(cert: x509.Certificate, issuer_cert: x509.Certificate = None):
+def check_revoked_crypto_cert(
+    cert: x509.Certificate, issuer_cert: x509.Certificate = None
+):
     if issuer_cert is not None:
         try:
             ocsp.check_revoked_crypto_cert(cert, issuer_cert)
@@ -33,7 +35,9 @@ def check_revoked_crypto_cert(cert: x509.Certificate, issuer_cert: x509.Certific
     try:
         crl.check_revoked_crypto_cert(cert)
     except exceptions.ExtensionMissing:
-        err_msg = ("OCSP and CRL extensions not found, "
-                   "couldn't check revocation status")
+        err_msg = (
+            "OCSP and CRL extensions not found, "
+            "couldn't check revocation status"
+        )
         logger.error(err_msg)
         raise exceptions.Error(err_msg)

--- a/pki_tools/utils.py
+++ b/pki_tools/utils.py
@@ -29,6 +29,7 @@ def check_revoked(
     if issuer_cert is not None:
         try:
             ocsp.check_revoked(cert, issuer_cert)
+            return
         except exceptions.ExtensionMissing:
             logger.debug("OCSP Extension missing, trying CRL next")
 

--- a/pki_tools/utils.py
+++ b/pki_tools/utils.py
@@ -1,8 +1,8 @@
 from cryptography import x509
 
-import crl
 from pki_tools import exceptions
 from pki_tools import ocsp
+from pki_tools import crl
 
 from loguru import logger
 
@@ -14,26 +14,26 @@ def cert_from_pem(cert_pem: str) -> x509.Certificate:
         raise exceptions.CertLoadError(e)
 
 
-def check_revoked(cert_pem: str, issuer_cert_pem: str = None):
+def check_revoked_pem(cert_pem: str, issuer_cert_pem: str = None):
     cert = cert_from_pem(cert_pem)
     issuer_cert = None
     if issuer_cert_pem is not None:
         issuer_cert = cert_from_pem(issuer_cert_pem)
 
-    check_revoked_crypto_cert(cert, issuer_cert)
+    check_revoked(cert, issuer_cert)
 
 
-def check_revoked_crypto_cert(
+def check_revoked(
     cert: x509.Certificate, issuer_cert: x509.Certificate = None
 ):
     if issuer_cert is not None:
         try:
-            ocsp.check_revoked_crypto_cert(cert, issuer_cert)
+            ocsp.check_revoked(cert, issuer_cert)
         except exceptions.ExtensionMissing:
             logger.debug("OCSP Extension missing, trying CRL next")
 
     try:
-        crl.check_revoked_crypto_cert(cert)
+        crl.check_revoked(cert)
     except exceptions.ExtensionMissing:
         err_msg = (
             "OCSP and CRL extensions not found, "

--- a/pki_tools/utils.py
+++ b/pki_tools/utils.py
@@ -1,10 +1,39 @@
 from cryptography import x509
 
-from pki_tools.exceptions import CertLoadError
+import crl
+from pki_tools import exceptions
+from pki_tools import ocsp
+
+from loguru import logger
 
 
 def cert_from_pem(cert_pem: str) -> x509.Certificate:
     try:
         return x509.load_pem_x509_certificate(cert_pem.encode())
     except ValueError as e:
-        raise CertLoadError(e)
+        raise exceptions.CertLoadError(e)
+
+
+def check_revoked(cert_pem: str, issuer_cert_pem: str = None):
+    cert = cert_from_pem(cert_pem)
+    issuer_cert = None
+    if issuer_cert_pem is not None:
+        issuer_cert = cert_from_pem(issuer_cert_pem)
+
+    check_revoked_crypto_cert(cert, issuer_cert)
+
+
+def check_revoked_crypto_cert(cert: x509.Certificate, issuer_cert: x509.Certificate = None):
+    if issuer_cert is not None:
+        try:
+            ocsp.check_revoked_crypto_cert(cert, issuer_cert)
+        except exceptions.ExtensionMissing:
+            logger.debug("OCSP Extension missing, trying CRL next")
+
+    try:
+        crl.check_revoked_crypto_cert(cert)
+    except exceptions.ExtensionMissing:
+        err_msg = ("OCSP and CRL extensions not found, "
+                   "couldn't check revocation status")
+        logger.error(err_msg)
+        raise exceptions.Error(err_msg)

--- a/pki_tools/utils.py
+++ b/pki_tools/utils.py
@@ -20,7 +20,7 @@ def is_revoked_pem(cert_pem: str, issuer_cert_pem: str = None) -> bool:
     if issuer_cert_pem is not None:
         issuer_cert = cert_from_pem(issuer_cert_pem)
 
-    is_revoked(cert, issuer_cert)
+    return is_revoked(cert, issuer_cert)
 
 
 def is_revoked(

--- a/pki_tools/utils.py
+++ b/pki_tools/utils.py
@@ -14,27 +14,26 @@ def cert_from_pem(cert_pem: str) -> x509.Certificate:
         raise exceptions.CertLoadError(e)
 
 
-def check_revoked_pem(cert_pem: str, issuer_cert_pem: str = None):
+def is_revoked_pem(cert_pem: str, issuer_cert_pem: str = None) -> bool:
     cert = cert_from_pem(cert_pem)
     issuer_cert = None
     if issuer_cert_pem is not None:
         issuer_cert = cert_from_pem(issuer_cert_pem)
 
-    check_revoked(cert, issuer_cert)
+    is_revoked(cert, issuer_cert)
 
 
-def check_revoked(
+def is_revoked(
     cert: x509.Certificate, issuer_cert: x509.Certificate = None
-):
+) -> bool:
     if issuer_cert is not None:
         try:
-            ocsp.check_revoked(cert, issuer_cert)
-            return
+            return ocsp.is_revoked(cert, issuer_cert)
         except exceptions.ExtensionMissing:
             logger.debug("OCSP Extension missing, trying CRL next")
 
     try:
-        crl.check_revoked(cert)
+        return crl.is_revoked(cert)
     except exceptions.ExtensionMissing:
         err_msg = (
             "OCSP and CRL extensions not found, "

--- a/poetry.lock
+++ b/poetry.lock
@@ -240,7 +240,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 files = [
@@ -400,6 +400,25 @@ files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
+
+[[package]]
+name = "loguru"
+version = "0.7.2"
+description = "Python logging made (stupidly) simple"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "loguru-0.7.2-py3-none-any.whl", hash = "sha256:003d71e3d3ed35f0f8984898359d65b79e5b21943f78af86aa5491210429b8eb"},
+    {file = "loguru-0.7.2.tar.gz", hash = "sha256:e671a53522515f34fd406340ee968cb9ecafbc4b36c679da03c18fd8d0bd51ac"},
+]
+
+[package.dependencies]
+colorama = {version = ">=0.3.4", markers = "sys_platform == \"win32\""}
+win32-setctime = {version = ">=1.0.0", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+dev = ["Sphinx (==7.2.5)", "colorama (==0.4.5)", "colorama (==0.4.6)", "exceptiongroup (==1.1.3)", "freezegun (==1.1.0)", "freezegun (==1.2.2)", "mypy (==v0.910)", "mypy (==v0.971)", "mypy (==v1.4.1)", "mypy (==v1.5.1)", "pre-commit (==3.4.0)", "pytest (==6.1.2)", "pytest (==7.4.0)", "pytest-cov (==2.12.1)", "pytest-cov (==4.1.0)", "pytest-mypy-plugins (==1.9.3)", "pytest-mypy-plugins (==3.0.0)", "sphinx-autobuild (==2021.3.14)", "sphinx-rtd-theme (==1.3.0)", "tox (==3.27.1)", "tox (==4.11.0)"]
 
 [[package]]
 name = "mypy-extensions"
@@ -632,7 +651,22 @@ secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
+[[package]]
+name = "win32-setctime"
+version = "1.1.0"
+description = "A small Python utility to set file creation time on Windows"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "win32_setctime-1.1.0-py3-none-any.whl", hash = "sha256:231db239e959c2fe7eb1d7dc129f11172354f98361c4fa2d6d2d7e278baa8aad"},
+    {file = "win32_setctime-1.1.0.tar.gz", hash = "sha256:15cf5750465118d6929ae4de4eb46e8edae9a5634350c01ba582df868e932cb2"},
+]
+
+[package.extras]
+dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "c29a5531ff65589611d98797ed88e6518d8f95e3b348e95b33f1b5c2a6e5e424"
+content-hash = "180ce421d3935915e1c908df3d3d28ff6897353c42acdd5700aa008094032778"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ repository = "https://github.com/fulder/pki-tools"
 python = "^3.8"
 cryptography = ">=39.0.1,<42.0.0"
 requests = "^2.28.2"
+loguru = "^0.7.2"
 
 [tool.poetry.group.test]
 optional = true

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,3 @@
-
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 
@@ -113,7 +112,6 @@ def _create_cert(key_pair, add_crl_extension=True, add_aia_extension=True):
 @pytest.fixture()
 def cert_pem_string(cert):
     return cert.public_bytes(serialization.Encoding.PEM).decode()
-
 
 
 def _create_mocked_ocsp_response(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,10 +1,16 @@
+
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+from cryptography import x509
+from cryptography.x509 import NameOID
+
 import datetime
 
 import pytest
-from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.x509 import NameOID
+from cryptography.hazmat.primitives._serialization import Encoding
+from cryptography.x509 import ocsp
 
 
 TEST_DISTRIBUTION_POINT_URL = "test_url"
@@ -107,3 +113,51 @@ def _create_cert(key_pair, add_crl_extension=True, add_aia_extension=True):
 @pytest.fixture()
 def cert_pem_string(cert):
     return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+
+def _create_mocked_ocsp_response(
+    cert, key_pair, status=ocsp.OCSPCertStatus.GOOD, revocation_time=None
+):
+    builder = ocsp.OCSPResponseBuilder()
+    builder = builder.add_response(
+        cert=cert,
+        issuer=cert,
+        algorithm=hashes.SHA256(),
+        cert_status=status,
+        this_update=datetime.datetime.now(),
+        next_update=datetime.datetime.now(),
+        revocation_time=revocation_time,
+        revocation_reason=None,
+    ).responder_id(ocsp.OCSPResponderEncoding.HASH, cert)
+    return builder.sign(key_pair, hashes.SHA256()).public_bytes(Encoding.DER)
+
+
+def _create_crl(keypair, revoked_serials):
+    one_day = datetime.timedelta(days=1)
+    crl = x509.CertificateRevocationListBuilder()
+    crl = crl.issuer_name(
+        x509.Name(
+            [
+                x509.NameAttribute(NameOID.COMMON_NAME, "cryptography.io CA"),
+            ]
+        )
+    )
+    crl = crl.last_update(datetime.datetime.today())
+    crl = crl.next_update(datetime.datetime.today() + one_day)
+
+    for serial in revoked_serials:
+        next_revoked_cert = (
+            x509.RevokedCertificateBuilder()
+            .serial_number(
+                serial,
+            )
+            .revocation_date(
+                datetime.datetime.today(),
+            )
+            .build()
+        )
+
+        crl = crl.add_revoked_certificate(next_revoked_cert)
+
+    return crl.sign(private_key=keypair, algorithm=hashes.SHA256())

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,109 @@
+import datetime
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509 import NameOID
+
+
+TEST_DISTRIBUTION_POINT_URL = "test_url"
+TEST_ACCESS_DESCRIPTION = "test-url"
+
+
+@pytest.fixture()
+def mocked_requests_get(mocker):
+    return mocker.patch("requests.get")
+
+
+@pytest.fixture()
+def key_pair():
+    return rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+
+
+@pytest.fixture()
+def cert(key_pair):
+    return _create_cert(key_pair)
+
+
+def _create_cert(key_pair, add_crl_extension=True, add_aia_extension=True):
+    subject = issuer = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
+            x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "California"),
+            x509.NameAttribute(NameOID.LOCALITY_NAME, "San Francisco"),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "My Company"),
+            x509.NameAttribute(NameOID.COMMON_NAME, "mysite.com"),
+        ]
+    )
+
+    cert_builder = (
+        x509.CertificateBuilder()
+        .subject_name(
+            subject,
+        )
+        .issuer_name(
+            issuer,
+        )
+        .serial_number(
+            x509.random_serial_number(),
+        )
+        .public_key(
+            key_pair.public_key(),
+        )
+        .not_valid_before(
+            datetime.datetime.utcnow(),
+        )
+        .not_valid_after(
+            datetime.datetime.utcnow() + datetime.timedelta(days=10),
+        )
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName("localhost")]),
+            critical=False,
+        )
+    )
+
+    if add_crl_extension:
+        cert_builder = cert_builder.add_extension(
+            x509.CRLDistributionPoints(
+                [
+                    x509.DistributionPoint(
+                        full_name=[
+                            x509.UniformResourceIdentifier(
+                                value=TEST_DISTRIBUTION_POINT_URL,
+                            ),
+                        ],
+                        relative_name=None,
+                        reasons=None,
+                        crl_issuer=None,
+                    ),
+                ]
+            ),
+            critical=False,
+        )
+    if add_aia_extension:
+        cert_builder = cert_builder.add_extension(
+            x509.AuthorityInformationAccess(
+                [
+                    x509.AccessDescription(
+                        access_method=x509.AuthorityInformationAccessOID.OCSP,
+                        access_location=x509.UniformResourceIdentifier(
+                            value=TEST_ACCESS_DESCRIPTION,
+                        ),
+                    )
+                ]
+            ),
+            critical=False,
+        )
+
+    cert = cert_builder.sign(key_pair, hashes.SHA256())
+
+    return cert
+
+
+@pytest.fixture()
+def cert_pem_string(cert):
+    return cert.public_bytes(serialization.Encoding.PEM).decode()

--- a/test/test_crl.py
+++ b/test/test_crl.py
@@ -3,7 +3,6 @@ import datetime
 import pytest
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509 import NameOID
 
 from pki_tools.exceptions import (
@@ -13,92 +12,7 @@ from pki_tools.exceptions import (
     CrlLoadError,
 )
 from pki_tools.crl import check_revoked_pem
-
-TEST_DISTRIBUTION_POINT_URL = "test_url"
-
-
-@pytest.fixture()
-def mocked_requests_get(mocker):
-    return mocker.patch("requests.get")
-
-
-@pytest.fixture()
-def key_pair():
-    return rsa.generate_private_key(
-        public_exponent=65537,
-        key_size=2048,
-    )
-
-
-@pytest.fixture()
-def cert(key_pair):
-    return _create_cert(key_pair)
-
-
-def _create_cert(key_pair, add_crl_extension=True):
-    subject = issuer = x509.Name(
-        [
-            x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
-            x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "California"),
-            x509.NameAttribute(NameOID.LOCALITY_NAME, "San Francisco"),
-            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "My Company"),
-            x509.NameAttribute(NameOID.COMMON_NAME, "mysite.com"),
-        ]
-    )
-
-    cert_builder = (
-        x509.CertificateBuilder()
-        .subject_name(
-            subject,
-        )
-        .issuer_name(
-            issuer,
-        )
-        .serial_number(
-            x509.random_serial_number(),
-        )
-        .public_key(
-            key_pair.public_key(),
-        )
-        .not_valid_before(
-            datetime.datetime.utcnow(),
-        )
-        .not_valid_after(
-            datetime.datetime.utcnow() + datetime.timedelta(days=10),
-        )
-        .add_extension(
-            x509.SubjectAlternativeName([x509.DNSName("localhost")]),
-            critical=False,
-        )
-    )
-
-    if add_crl_extension:
-        cert_builder = cert_builder.add_extension(
-            x509.CRLDistributionPoints(
-                [
-                    x509.DistributionPoint(
-                        full_name=[
-                            x509.UniformResourceIdentifier(
-                                value=TEST_DISTRIBUTION_POINT_URL,
-                            ),
-                        ],
-                        relative_name=None,
-                        reasons=None,
-                        crl_issuer=None,
-                    ),
-                ]
-            ),
-            critical=False,
-        )
-
-    cert = cert_builder.sign(key_pair, hashes.SHA256())
-
-    return cert
-
-
-@pytest.fixture()
-def cert_pem_string(cert):
-    return cert.public_bytes(serialization.Encoding.PEM).decode()
+from conftest import _create_cert
 
 
 def _create_crl(keypair, revoked_serials):

--- a/test/test_crl.py
+++ b/test/test_crl.py
@@ -1,56 +1,11 @@
 import pytest
-from cryptography.hazmat.primitives import serialization
 
 
 from pki_tools.exceptions import (
-    ExtensionMissing,
     CrlFetchFailure,
     CrlLoadError,
 )
 from pki_tools.crl import is_revoked_pem
-from conftest import _create_cert, _create_crl
-
-
-def test_not_revoked_cert(key_pair, mocked_requests_get, cert_pem_string):
-    crl = _create_crl(key_pair, [])
-    crl_der = crl.public_bytes(serialization.Encoding.DER)
-
-    mocked_requests_get.return_value.status_code = 200
-    mocked_requests_get.return_value.content = crl_der
-
-    is_revoked_pem(cert_pem_string)
-
-
-def test_not_revoked_cert_pem_crl(
-    key_pair, mocked_requests_get, cert_pem_string
-):
-    crl = _create_crl(key_pair, [])
-    crl_pem = crl.public_bytes(serialization.Encoding.PEM)
-
-    mocked_requests_get.return_value.status_code = 200
-    mocked_requests_get.return_value.content = crl_pem
-
-    is_revoked_pem(cert_pem_string)
-
-
-def test_is_revoked_revoked_cert(
-    key_pair, mocked_requests_get, cert, cert_pem_string
-):
-    crl = _create_crl(key_pair, [cert.serial_number])
-    crl_der = crl.public_bytes(serialization.Encoding.DER)
-
-    mocked_requests_get.return_value.status_code = 200
-    mocked_requests_get.return_value.content = crl_der
-
-    assert is_revoked_pem(cert_pem_string)
-
-
-def test_cert_missing_crl_extension(key_pair):
-    cert = _create_cert(key_pair, add_crl_extension=False)
-    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
-
-    with pytest.raises(ExtensionMissing):
-        is_revoked_pem(cert_pem)
 
 
 def test_crl_fetch_error(mocked_requests_get, cert_pem_string):

--- a/test/test_crl.py
+++ b/test/test_crl.py
@@ -1,9 +1,6 @@
-import datetime
-
 import pytest
-from cryptography import x509
-from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.x509 import NameOID
+from cryptography.hazmat.primitives import serialization
+
 
 from pki_tools.exceptions import (
     ExtensionMissing,
@@ -12,37 +9,7 @@ from pki_tools.exceptions import (
     CrlLoadError,
 )
 from pki_tools.crl import check_revoked_pem
-from conftest import _create_cert
-
-
-def _create_crl(keypair, revoked_serials):
-    one_day = datetime.timedelta(days=1)
-    crl = x509.CertificateRevocationListBuilder()
-    crl = crl.issuer_name(
-        x509.Name(
-            [
-                x509.NameAttribute(NameOID.COMMON_NAME, "cryptography.io CA"),
-            ]
-        )
-    )
-    crl = crl.last_update(datetime.datetime.today())
-    crl = crl.next_update(datetime.datetime.today() + one_day)
-
-    for serial in revoked_serials:
-        next_revoked_cert = (
-            x509.RevokedCertificateBuilder()
-            .serial_number(
-                serial,
-            )
-            .revocation_date(
-                datetime.datetime.today(),
-            )
-            .build()
-        )
-
-        crl = crl.add_revoked_certificate(next_revoked_cert)
-
-    return crl.sign(private_key=keypair, algorithm=hashes.SHA256())
+from conftest import _create_cert, _create_crl
 
 
 def test_not_revoked_cert(key_pair, mocked_requests_get, cert_pem_string):

--- a/test/test_ocsp.py
+++ b/test/test_ocsp.py
@@ -7,13 +7,8 @@ from cryptography.hazmat.primitives._serialization import Encoding
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509 import NameOID, ocsp
 
-from pki_tools.ocsp import (
-    ExtensionMissing,
-    OcspFetchFailure,
-    Revoked,
-    check_revoked,
-    check_revoked_crypto_cert,
-)
+from pki_tools.exceptions import ExtensionMissing, Revoked, OcspFetchFailure
+from pki_tools.ocsp import check_revoked_pem
 
 TEST_ACCESS_DESCRIPTION = "test-url"
 
@@ -115,13 +110,15 @@ def cert_pem_string(cert):
     return cert.public_bytes(serialization.Encoding.PEM).decode()
 
 
-def test_not_revoked_cert(mocked_requests_get, cert, key_pair):
+def test_not_revoked_cert(
+    mocked_requests_get, cert, key_pair, cert_pem_string
+):
     mocked_requests_get.return_value.status_code = 200
     mocked_requests_get.return_value.content = _create_mocked_ocsp_response(
         cert, key_pair
     )
 
-    check_revoked_crypto_cert(cert, cert)
+    check_revoked_pem(cert_pem_string, cert_pem_string)
 
 
 def test_not_revoked_cert_pem(
@@ -132,10 +129,12 @@ def test_not_revoked_cert_pem(
         cert, key_pair
     )
 
-    check_revoked(cert_pem_string, cert_pem_string)
+    check_revoked_pem(cert_pem_string, cert_pem_string)
 
 
-def test_check_revoked_revoked_cert(key_pair, mocked_requests_get, cert):
+def test_check_revoked_revoked_cert(
+    key_pair, mocked_requests_get, cert, cert_pem_string
+):
     mocked_requests_get.return_value.status_code = 200
     mocked_requests_get.return_value.content = _create_mocked_ocsp_response(
         cert,
@@ -146,7 +145,7 @@ def test_check_revoked_revoked_cert(key_pair, mocked_requests_get, cert):
 
     exp_msg = f"Certificate with serial: {cert.serial_number} is revoked since"
     with pytest.raises(Revoked, match=exp_msg):
-        check_revoked_crypto_cert(cert, cert)
+        check_revoked_pem(cert_pem_string, cert_pem_string)
 
 
 def test_cert_missing_extension(key_pair):
@@ -154,11 +153,11 @@ def test_cert_missing_extension(key_pair):
     cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
 
     with pytest.raises(ExtensionMissing):
-        check_revoked(cert_pem, cert_pem)
+        check_revoked_pem(cert_pem, cert_pem)
 
 
 def test_ocsp_fetch_error(mocked_requests_get, cert_pem_string):
     mocked_requests_get.return_value.status_code = 503
 
     with pytest.raises(OcspFetchFailure):
-        check_revoked(cert_pem_string, cert_pem_string)
+        check_revoked_pem(cert_pem_string, cert_pem_string)

--- a/test/test_ocsp.py
+++ b/test/test_ocsp.py
@@ -1,35 +1,12 @@
 import datetime
 
 import pytest
-from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives._serialization import Encoding
+from cryptography.hazmat.primitives import serialization
 from cryptography.x509 import ocsp
 
 from pki_tools.exceptions import ExtensionMissing, Revoked, OcspFetchFailure
 from pki_tools.ocsp import check_revoked_pem
-from conftest import _create_cert
-
-
-def _create_mocked_ocsp_response(
-    cert, key_pair, status=ocsp.OCSPCertStatus.GOOD, revocation_time=None
-):
-    builder = ocsp.OCSPResponseBuilder()
-    builder = builder.add_response(
-        cert=cert,
-        issuer=cert,
-        algorithm=hashes.SHA256(),
-        cert_status=status,
-        this_update=datetime.datetime.now(),
-        next_update=datetime.datetime.now(),
-        revocation_time=revocation_time,
-        revocation_reason=None,
-    ).responder_id(ocsp.OCSPResponderEncoding.HASH, cert)
-    return builder.sign(key_pair, hashes.SHA256()).public_bytes(Encoding.DER)
-
-
-@pytest.fixture()
-def cert_pem_string(cert):
-    return cert.public_bytes(serialization.Encoding.PEM).decode()
+from conftest import _create_cert, _create_mocked_ocsp_response
 
 
 def test_not_revoked_cert(

--- a/test/test_ocsp.py
+++ b/test/test_ocsp.py
@@ -1,48 +1,9 @@
-import datetime
-
 import pytest
 from cryptography.hazmat.primitives import serialization
-from cryptography.x509 import ocsp
 
 from pki_tools.exceptions import ExtensionMissing, OcspFetchFailure
 from pki_tools.ocsp import is_revoked_pem
-from conftest import _create_cert, _create_mocked_ocsp_response
-
-
-def test_not_revoked_cert(
-    mocked_requests_get, cert, key_pair, cert_pem_string
-):
-    mocked_requests_get.return_value.status_code = 200
-    mocked_requests_get.return_value.content = _create_mocked_ocsp_response(
-        cert, key_pair
-    )
-
-    is_revoked_pem(cert_pem_string, cert_pem_string)
-
-
-def test_not_revoked_cert_pem(
-    mocked_requests_get, cert_pem_string, cert, key_pair
-):
-    mocked_requests_get.return_value.status_code = 200
-    mocked_requests_get.return_value.content = _create_mocked_ocsp_response(
-        cert, key_pair
-    )
-
-    is_revoked_pem(cert_pem_string, cert_pem_string)
-
-
-def test_is_revoked_revoked_cert(
-    key_pair, mocked_requests_get, cert, cert_pem_string
-):
-    mocked_requests_get.return_value.status_code = 200
-    mocked_requests_get.return_value.content = _create_mocked_ocsp_response(
-        cert,
-        key_pair,
-        status=ocsp.OCSPCertStatus.REVOKED,
-        revocation_time=datetime.datetime.now(),
-    )
-
-    assert is_revoked_pem(cert_pem_string, cert_pem_string)
+from conftest import _create_cert
 
 
 def test_cert_missing_extension(key_pair):

--- a/test/test_ocsp.py
+++ b/test/test_ocsp.py
@@ -1,91 +1,13 @@
 import datetime
 
 import pytest
-from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives._serialization import Encoding
-from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.x509 import NameOID, ocsp
+from cryptography.x509 import ocsp
 
 from pki_tools.exceptions import ExtensionMissing, Revoked, OcspFetchFailure
 from pki_tools.ocsp import check_revoked_pem
-
-TEST_ACCESS_DESCRIPTION = "test-url"
-
-
-@pytest.fixture()
-def mocked_requests_get(mocker):
-    return mocker.patch("requests.get")
-
-
-@pytest.fixture()
-def key_pair():
-    return rsa.generate_private_key(
-        public_exponent=65537,
-        key_size=2048,
-    )
-
-
-@pytest.fixture()
-def cert(key_pair):
-    return _create_cert(key_pair)
-
-
-def _create_cert(key_pair, add_aia_extension=True):
-    subject = issuer = x509.Name(
-        [
-            x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
-            x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "California"),
-            x509.NameAttribute(NameOID.LOCALITY_NAME, "San Francisco"),
-            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "My Company"),
-            x509.NameAttribute(NameOID.COMMON_NAME, "mysite.com"),
-        ]
-    )
-
-    cert_builder = (
-        x509.CertificateBuilder()
-        .subject_name(
-            subject,
-        )
-        .issuer_name(
-            issuer,
-        )
-        .serial_number(
-            x509.random_serial_number(),
-        )
-        .public_key(
-            key_pair.public_key(),
-        )
-        .not_valid_before(
-            datetime.datetime.utcnow(),
-        )
-        .not_valid_after(
-            datetime.datetime.utcnow() + datetime.timedelta(days=10),
-        )
-        .add_extension(
-            x509.SubjectAlternativeName([x509.DNSName("localhost")]),
-            critical=False,
-        )
-    )
-
-    if add_aia_extension:
-        cert_builder = cert_builder.add_extension(
-            x509.AuthorityInformationAccess(
-                [
-                    x509.AccessDescription(
-                        access_method=x509.AuthorityInformationAccessOID.OCSP,
-                        access_location=x509.UniformResourceIdentifier(
-                            value="test_server",
-                        ),
-                    )
-                ]
-            ),
-            critical=False,
-        )
-
-    cert = cert_builder.sign(key_pair, hashes.SHA256())
-
-    return cert
+from conftest import _create_cert
 
 
 def _create_mocked_ocsp_response(

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -18,4 +18,4 @@ def test_is_revoked_pem(
         cert, key_pair
     )
 
-    is_revoked_pem(cert_pem_string, cert_pem_string)
+    assert is_revoked_pem(cert_pem_string, cert_pem_string)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pki_tools.exceptions import CertLoadError
-from pki_tools.utils import cert_from_pem, check_revoked_pem
+from pki_tools.utils import cert_from_pem, is_revoked_pem
 from conftest import _create_mocked_ocsp_response
 
 
@@ -10,10 +10,12 @@ def test_cert_load_error():
         cert_from_pem("BAD_PEM_DATA")
 
 
-def test_check_revoked_pem(cert_pem_string, mocked_requests_get, cert, key_pair):
+def test_is_revoked_pem(
+    cert_pem_string, mocked_requests_get, cert, key_pair
+):
     mocked_requests_get.return_value.status_code = 200
     mocked_requests_get.return_value.content = _create_mocked_ocsp_response(
         cert, key_pair
     )
 
-    check_revoked_pem(cert_pem_string, cert_pem_string)
+    is_revoked_pem(cert_pem_string, cert_pem_string)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -10,12 +10,10 @@ def test_cert_load_error():
         cert_from_pem("BAD_PEM_DATA")
 
 
-def test_is_revoked_pem(
-    cert_pem_string, mocked_requests_get, cert, key_pair
-):
+def test_is_revoked_pem(cert_pem_string, mocked_requests_get, cert, key_pair):
     mocked_requests_get.return_value.status_code = 200
     mocked_requests_get.return_value.content = _create_mocked_ocsp_response(
         cert, key_pair
     )
 
-    assert is_revoked_pem(cert_pem_string, cert_pem_string)
+    assert not is_revoked_pem(cert_pem_string, cert_pem_string)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,8 +1,12 @@
-import pytest
+import datetime
 
-from pki_tools.exceptions import CertLoadError
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.x509 import ocsp
+
+from pki_tools.exceptions import CertLoadError, Error
 from pki_tools.utils import cert_from_pem, is_revoked_pem
-from conftest import _create_mocked_ocsp_response
+from conftest import _create_mocked_ocsp_response, _create_cert, _create_crl
 
 
 def test_cert_load_error():
@@ -10,10 +14,62 @@ def test_cert_load_error():
         cert_from_pem("BAD_PEM_DATA")
 
 
-def test_is_revoked_pem(cert_pem_string, mocked_requests_get, cert, key_pair):
+def test_is_revoked_pem_ocsp(
+    cert_pem_string, mocked_requests_get, cert, key_pair
+):
     mocked_requests_get.return_value.status_code = 200
     mocked_requests_get.return_value.content = _create_mocked_ocsp_response(
         cert, key_pair
     )
 
     assert not is_revoked_pem(cert_pem_string, cert_pem_string)
+
+
+def test_is_revoked_pem_crl(key_pair, mocked_requests_get):
+    cert = _create_cert(key_pair, add_aia_extension=False)
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+
+    crl = _create_crl(key_pair, [])
+    crl_der = crl.public_bytes(serialization.Encoding.DER)
+
+    mocked_requests_get.return_value.status_code = 200
+    mocked_requests_get.return_value.content = crl_der
+
+    assert not is_revoked_pem(cert_pem, cert_pem)
+
+
+def test_is_revoked_pem_ocsp_revoked(
+    cert_pem_string, mocked_requests_get, cert, key_pair
+):
+    mocked_requests_get.return_value.status_code = 200
+    mocked_requests_get.return_value.content = _create_mocked_ocsp_response(
+        cert,
+        key_pair,
+        status=ocsp.OCSPCertStatus.REVOKED,
+        revocation_time=datetime.datetime.now(),
+    )
+
+    assert is_revoked_pem(cert_pem_string, cert_pem_string)
+
+
+def test_is_revoked_pem_crl_revoked(mocked_requests_get, key_pair):
+    cert = _create_cert(key_pair, add_aia_extension=False)
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+
+    crl = _create_crl(key_pair, [cert.serial_number])
+    crl_der = crl.public_bytes(serialization.Encoding.DER)
+
+    mocked_requests_get.return_value.status_code = 200
+    mocked_requests_get.return_value.content = crl_der
+
+    assert is_revoked_pem(cert_pem, cert_pem)
+
+
+def test_is_revoked_missing_extensions(key_pair):
+    cert = _create_cert(
+        key_pair, add_crl_extension=False, add_aia_extension=False
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+
+    with pytest.raises(Error):
+        is_revoked_pem(cert_pem)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,9 +1,19 @@
 import pytest
 
 from pki_tools.exceptions import CertLoadError
-from pki_tools.utils import cert_from_pem
+from pki_tools.utils import cert_from_pem, check_revoked_pem
+from conftest import _create_mocked_ocsp_response
 
 
 def test_cert_load_error():
     with pytest.raises(CertLoadError):
         cert_from_pem("BAD_PEM_DATA")
+
+
+def test_check_revoked_pem(cert_pem_string, mocked_requests_get, cert, key_pair):
+    mocked_requests_get.return_value.status_code = 200
+    mocked_requests_get.return_value.content = _create_mocked_ocsp_response(
+        cert, key_pair
+    )
+
+    check_revoked_pem(cert_pem_string, cert_pem_string)


### PR DESCRIPTION
Add new `utils.is_revoked` (and `utils.is_revoked_pem`) function checking OCSP first and if it's not present falling back to CRL)

Extra (breaking) changes: 
* Rename `crl.check_revoked_crypto_cert` to `crl.is_revoked`
* Rename `crl.check_revoked` to `crl.is_revoked_pem`
* Rename `ocsp.check_revoked_crypto_cert` to `ocsp.is_revoked`
* Rename `ocsp.check_revoked` to `ocsp.is_revoked_pem`