### PR TITLE
fix: not revoked OCSP certs bug

### DIFF
--- a/pki_tools/ocsp.py
+++ b/pki_tools/ocsp.py
@@ -102,8 +102,7 @@ def is_revoked(
         try:
             req_path = _construct_req_path(cert, issuer_cert, alg)
 
-            if _check_ocsp_status(aia_exs, req_path, cert):
-                return True
+            return _check_ocsp_status(aia_exs, req_path, cert)
         except exceptions.OcspInvalidResponseStatus:
             logger.debug(f"OCSP check with: {alg.name} failed, trying another")
             if i + 1 == len(OCSP_ALGORITHMS_TO_CHECK):

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -51,6 +51,16 @@ def test_is_revoked_pem_ocsp(
     assert not is_revoked(cert_pem_string, types.PemCert(cert_pem_string))
 
 
+def test_is_revoked_pem_failure(
+    cert_pem_string,
+    mocked_requests_get,
+):
+    mocked_requests_get.side_effect = OcspInvalidResponseStatus
+
+    with pytest.raises(OcspInvalidResponseStatus):
+        assert is_revoked(cert_pem_string, types.PemCert(cert_pem_string))
+
+
 def test_is_revoked_cert_ocsp(mocked_requests_get, cert, key_pair):
     mocked_requests_get.return_value.status_code = 200
     mocked_requests_get.return_value.content = _create_mocked_ocsp_response(

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -3,11 +3,14 @@ import os
 from unittest.mock import MagicMock
 
 import pytest
-import requests
 from cryptography.hazmat.primitives import serialization
 from cryptography.x509 import ocsp
 
-from pki_tools.exceptions import CertLoadError, Error, OcspInvalidResponseStatus
+from pki_tools.exceptions import (
+    CertLoadError,
+    Error,
+    OcspInvalidResponseStatus,
+)
 from pki_tools import (
     cert_from_pem,
     is_revoked,
@@ -35,20 +38,17 @@ def test_is_revoked_pem_ocsp(
 ):
     correct_res = MagicMock()
     correct_res.status_code = 200
-    correct_res.content = _create_mocked_ocsp_response(
-        cert, key_pair
-    )
+    correct_res.content = _create_mocked_ocsp_response(cert, key_pair)
 
     mocked_requests_get.side_effect = [
         OcspInvalidResponseStatus,
         OcspInvalidResponseStatus,
         OcspInvalidResponseStatus,
         correct_res,
-        OcspInvalidResponseStatus
+        OcspInvalidResponseStatus,
     ]
 
     assert not is_revoked(cert_pem_string, types.PemCert(cert_pem_string))
-
 
 
 def test_is_revoked_cert_ocsp(mocked_requests_get, cert, key_pair):


### PR DESCRIPTION
When the revocation status was OK but only one algorithm in the middle returned it the rest were still checked and raised an invalid exception.