### PR TITLE
chore: bump python 3.9 patch version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9.3"
+          - "3.9.12"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"
+          - "3.9.3"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Python Badge](https://img.shields.io/badge/python-3.9%2B-7393B3.svg?logo=python&logoColor=white)](https://devguide.python.org/versions/)
+[![Python Badge](https://img.shields.io/badge/python-3.9.3%2B-7393B3.svg?logo=python&logoColor=white)](https://devguide.python.org/versions/)
 [![Discord](https://img.shields.io/badge/chat-gray?logo=discord&logoColor=white)](https://discord.gg/x7k6kJC426)
 [![Coverage](https://coverage-badge.samuelcolvin.workers.dev/fulder/pki-tools.svg)](https://coverage-badge.samuelcolvin.workers.dev/redirect/fulder/pki-tools)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1362,5 +1362,5 @@ type = ["pytest-mypy"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.9"
-content-hash = "d4cf028f9c08fb74b2ff151e54ead9dc90ce159ea19acf6ec47883cea27a63fa"
+python-versions = "^3.9.3"
+content-hash = "5c244c69d0a5a67ad24fc23fca92bbf7959b3618b06f831e1d064296ed98e826"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ repository = "https://github.com/fulder/pki-tools"
 "Bug Tracker" = "https://github.com/fulder/pki-tools/issues"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.9.3"
 cryptography = ">=42.0.0,<44.0.0"
 loguru = "^0.7.3"
 pydantic = "^2.10.6"


### PR DESCRIPTION
Change requirement from python >= 3.9.X to  >= 3.9.3 due to bugs in cryptography with lower versions, see: https://github.com/pyca/cryptography/pull/12045