### PR TITLE
fix: deprecations

### DIFF
--- a/pki_tools/crl.py
+++ b/pki_tools/crl.py
@@ -6,7 +6,12 @@ from loguru import logger
 from pki_tools.types.extensions import UniformResourceIdentifier
 from pki_tools.types.chain import Chain
 from pki_tools.types.certificate import Certificate
-from pki_tools.exceptions import ExtensionMissing, CrlIdpInvalid, FetchFailure, LoadError
+from pki_tools.exceptions import (
+    ExtensionMissing,
+    CrlIdpInvalid,
+    FetchFailure,
+    LoadError,
+)
 from pki_tools.types.crl import CertificateRevocationList
 
 
@@ -93,8 +98,7 @@ def _is_revoked(
         for full_name in dist_point.full_name:
             if not isinstance(full_name, UniformResourceIdentifier):
                 log.warning(
-                    "CRL Distribution Point is not "
-                    "UniformResourceIdentifier"
+                    "CRL Distribution Point is not UniformResourceIdentifier"
                 )
                 continue
 
@@ -112,7 +116,6 @@ def _is_revoked(
                 continue
 
             fetched_crl = True
-                
 
             issuer = crl_issuer.get_issuer(crl)
 

--- a/pki_tools/types/certificate.py
+++ b/pki_tools/types/certificate.py
@@ -391,7 +391,7 @@ class Certificate(InitCryptoParser):
 
         if not hasattr(self, "_key_pair"):
             raise MissingInit(
-                f"Please use Certificate.{self._init_func} " f"function"
+                f"Please use Certificate.{self._init_func} function"
             )
 
         subject = self.subject._to_cryptography()

--- a/pki_tools/types/certificates.py
+++ b/pki_tools/types/certificates.py
@@ -157,8 +157,8 @@ class Certificates(CryptoParser):
         count = 0
         for cert in self.certificates:
             count += 1
-            ret += f"{'-'*10}Certificate #{count}{'-'*10}\n"
+            ret += f"{'-' * 10}Certificate #{count}{'-' * 10}\n"
             ret += str(cert)
-            ret += f"{'-'*34}\n"
+            ret += f"{'-' * 34}\n"
         ret += f"Chain certificate count: {count}"
         return ret

--- a/pki_tools/types/extensions.py
+++ b/pki_tools/types/extensions.py
@@ -322,9 +322,9 @@ class AuthorityKeyIdentifier(Extension):
                 authority_cert_issuer.append(general_name._string_dict())
             ret["Authority Cert Issuer"] = authority_cert_issuer
         if self.authority_cert_serial_number is not None:
-            ret[
-                "Authority Cert Serial Number"
-            ] = self.authority_cert_serial_number
+            ret["Authority Cert Serial Number"] = (
+                self.authority_cert_serial_number
+            )
 
         if ret:
             return {self.name: ret}
@@ -945,13 +945,13 @@ class PolicyConstraints(Extension):
         ret = {self.name: {}}
 
         if self.require_explicit_policy is not None:
-            ret[self.name][
-                "Require Explicit Policy"
-            ] = self.require_explicit_policy
+            ret[self.name]["Require Explicit Policy"] = (
+                self.require_explicit_policy
+            )
         if self.inhibit_policy_mapping is not None:
-            ret[self.name][
-                "Inhibit Policy Mapping"
-            ] = self.inhibit_policy_mapping
+            ret[self.name]["Inhibit Policy Mapping"] = (
+                self.inhibit_policy_mapping
+            )
 
         return ret
 
@@ -1210,9 +1210,9 @@ class DistributionPoint(CryptoParser):
             for full_name in self.full_name:
                 ret["Full Name"].append(full_name._string_dict())
         if self.name_relative_to_crl_issuer is not None:
-            ret[
-                "Name Relative To CRL Issuer"
-            ] = self.name_relative_to_crl_issuer._string_dict()
+            ret["Name Relative To CRL Issuer"] = (
+                self.name_relative_to_crl_issuer._string_dict()
+            )
         if self.reasons is not None:
             ret["Reasons"] = []
             for reason in self.reasons:
@@ -1388,9 +1388,9 @@ class IssuingDistributionPoint(Extension):
             for full_name in self.full_name:
                 ret["Full Name"].append(full_name._string_dict())
         if self.name_relative_to_crl_issuer is not None:
-            ret[
-                "Name Relative To CRL Issuer"
-            ] = self.name_relative_to_crl_issuer._string_dict()
+            ret["Name Relative To CRL Issuer"] = (
+                self.name_relative_to_crl_issuer._string_dict()
+            )
         return ret
 
     def _to_cryptography(self) -> x509.IssuingDistributionPoint:

--- a/pki_tools/types/extensions.py
+++ b/pki_tools/types/extensions.py
@@ -445,7 +445,7 @@ class KeyUsage(Extension):
 
     def _string_dict(self):
         true_fields = []
-        for field in self.model_fields:
+        for field in KeyUsage.model_fields:
             if field == "critical":
                 continue
 
@@ -1691,7 +1691,7 @@ class Extensions(CryptoParser):
     )
 
     def __iter__(self) -> Iterable[Extension]:
-        for field_name, field in self.model_fields.items():
+        for field_name, field in Extensions.model_fields.items():
             val = getattr(self, field_name)
             if val is None:
                 continue
@@ -1713,7 +1713,7 @@ class Extensions(CryptoParser):
         """
         extensions_dict = {"_x509_obj": cert_extensions}
 
-        for name, field_info in cls.model_fields.items():
+        for name, field_info in Extensions.model_fields.items():
             class_type = typing.get_args(field_info.annotation)[0]
             oid = ObjectIdentifier(field_info.alias)
             try:
@@ -1741,7 +1741,7 @@ class Extensions(CryptoParser):
 
     def _string_dict(self):
         extensions = {}
-        for field_name in self.model_fields:
+        for field_name in Extensions.model_fields:
             att_val = getattr(self, field_name)
 
             if att_val is None or str(att_val) == "":
@@ -1753,7 +1753,7 @@ class Extensions(CryptoParser):
 
     def _to_cryptography(self) -> x509.Extensions:
         extensions = []
-        for field_name in self.model_fields:
+        for field_name in Extensions.model_fields:
             att_val = getattr(self, field_name)
 
             if att_val is None or str(att_val) == "":

--- a/pki_tools/types/name.py
+++ b/pki_tools/types/name.py
@@ -93,7 +93,7 @@ class Name(CryptoParser):
 
     def _to_cryptography(self) -> x509.Name:
         name_attributes = []
-        for name, field in self.model_fields.items():
+        for name, field in Name.model_fields.items():
             object_identifier = ObjectIdentifier(field.alias)
             field_vals = getattr(self, name)
             for val in field_vals:

--- a/pki_tools/types/ocsp.py
+++ b/pki_tools/types/ocsp.py
@@ -378,7 +378,7 @@ class OCSPRequest(InitCryptoParser):
     def _to_cryptography(self) -> ocsp.OCSPRequest:
         if not hasattr(self, "_cert"):
             raise MissingInit(
-                f"Please use " f"OCSPRequest.{self._init_func} function"
+                f"Please use OCSPRequest.{self._init_func} function"
             )
 
         builder = ocsp.OCSPRequestBuilder()

--- a/pki_tools/types/signature_algorithm.py
+++ b/pki_tools/types/signature_algorithm.py
@@ -265,9 +265,9 @@ class SignatureAlgorithm(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     algorithm: HashAlgorithm
-    parameters: Optional[
-        Union[PSSPadding, PKCS1v15Padding, ECDSAPadding]
-    ] = None
+    parameters: Optional[Union[PSSPadding, PKCS1v15Padding, ECDSAPadding]] = (
+        None
+    )
 
     @classmethod
     def from_cryptography(

--- a/pki_tools/types/utils.py
+++ b/pki_tools/types/utils.py
@@ -60,7 +60,6 @@ def _download_server_certificate(hostname: str, cache_ttl: int = None):
 def _download_cached(uri: str, ttl: int = None) -> httpx.Response:
     ret = HTTPX_CLIENT.get(uri)
 
-
     if ret.status_code != 200:
         logger.bind(status=ret.status_code).error(
             "Failed to fetch issuer from URI"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ addopts = "--cov=pki_tools --cov-report term-missing --cov-report=html -v -n aut
 [tool.ruff]
 line-length = 79
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "./pki_tools/__init__.py" = ["F401"]
 "./pki_tools/types/__init__.py" = ["F401"]
 "./pki_tools/funcs/__init__.py" = ["F401"]

--- a/scripts/run_examples.sh
+++ b/scripts/run_examples.sh
@@ -4,7 +4,7 @@ RED='\033[0;31m'
 NC='\033[0m' # No Color
 
 skip_run=(
-
+ "check_revocation_ocsp.py"
 )
 exclude_outputs=(
   "create_csr.py"

--- a/scripts/run_examples.sh
+++ b/scripts/run_examples.sh
@@ -25,6 +25,7 @@ while IFS= read -r -d '' file; do
   file_name=$(basename "$file")
 
   if [[ "${skip_run[@]}" =~ "${file_name}" ]]; then
+    echo "Skipping ${file_name}..."
     continue
   fi
 

--- a/test/test_crl.py
+++ b/test/test_crl.py
@@ -9,6 +9,7 @@ from conftest import _create_crl
 from pki_tools.exceptions import CrlIdpInvalid
 from unittest.mock import Mock
 
+
 def test_crl_fetch_error(mocked_requests_get, cert, chain):
     mocked_requests_get.return_value.status_code = 503
 


### PR DESCRIPTION
* `ruff` `pyproject.toml` property
* `pydantic` deprecation for v3 with `model_fields` property called from the class instead of instance

Extras:
* Reformat code using latest `ruff`.
* Skip flaky example with timeouts while downloading public Cert/Chain in `check_revocation_ocsp.py`