### PR TITLE
docs: fix mkdocs cross-reference warnings

### DIFF
--- a/docs/examples/check_revocation.md
+++ b/docs/examples/check_revocation.md
@@ -38,4 +38,4 @@
 ///
 
 For different ways of loading certificate and chain see: 
-[Loading objects][loading-objects].
+[Loading objects][loading-x509-objects].

--- a/pki_tools/funcs/check_revocation.py
+++ b/pki_tools/funcs/check_revocation.py
@@ -37,8 +37,8 @@ def is_revoked(
             to check revocation for.
         chain: The CA chain including one or more certificates and
             the issuer of the `cert`, signer of the OCSP response and CRL
-            issuer. See [Loading Chain][chain] for examples how the
-            chain can be created
+            issuer. See [Loading Chain][pki_tools.types.chain.Chain] for
+            examples how the chain can be created
         crl_cache_seconds: [CRL Only] Specifies how long the CRL should
             be cached, default is 1 hour.
         ocsp_res_cache_seconds: [OCSP Only] Specifies how long the OCSP
@@ -96,7 +96,7 @@ def is_revoked_multiple_issuers(
         cert: The [Certificate][pki_tools.types.certificate.Certificate]
             to check revocation for.
         cert_issuer: The CA chain including one or more certificates and
-            the issuer of the `cert`. See [Loading Chain][chain]
+            the issuer of the `cert`. See [Loading Chain][pki_tools.types.chain.Chain]
             for examples how the chain can be created.
         ocsp_issuer: The CA chain including one or more certificates used
             for signing of the OCSP response

--- a/pki_tools/types/certificate.py
+++ b/pki_tools/types/certificate.py
@@ -173,11 +173,11 @@ class Certificate(InitCryptoParser):
         cert: x509.Certificate,
     ) -> "Certificate":
         """
-        Create a Certificate object from a [cryptography.x509.Certificate][]
+        Create a Certificate object from a `cryptography.x509.Certificate`
         object.
 
         Args:
-            cert: The [cryptography.x509.Certificate][] object.
+            cert: The `cryptography.x509.Certificate` object.
 
         Returns:
             Certificate: The created Certificate object.

--- a/pki_tools/types/key_pair.py
+++ b/pki_tools/types/key_pair.py
@@ -206,7 +206,7 @@ class CryptoKeyPair(BaseModel):
     """
     Represents a cryptographic key pair.
 
-    Arguments:
+    Attributes:
         private_key: The private key
         public_key: The public key
     """
@@ -258,7 +258,7 @@ class DSAPublicKey(CryptoPublicKey):
         Create a DSAKeyPair from a cryptography key.
 
         Args:
-            key: The [cryptography.hazmat.primitives.asymmetric.dsa][]
+            key: The `cryptography.hazmat.primitives.asymmetric.dsa`
                 public key.
 
         Returns:
@@ -341,7 +341,7 @@ class DSAPrivateKey(CryptoPrivateKey):
         Create a DSAPrivateKey from a cryptography key.
 
         Args:
-            key: The [cryptography.hazmat.primitives.asymmetric.dsa][]
+            key: The `cryptography.hazmat.primitives.asymmetric.dsa`
                 private key.
 
         Returns:


### PR DESCRIPTION
The docs build emitted 13 warnings (all pre-existing). Fixes:

- CryptoKeyPair docstring: document private_key/public_key under Attributes: (pydantic fields, not constructor args), clearing the griffe warnings.
- Broken autoref links: [chain] -> Chain class ref; [loading-objects] ->
  the loading-x509-objects heading anchor.
- cryptography x509.Certificate / asymmetric.dsa autorefs: convert to plain code spans. They never resolve because cryptography.io returns 403 to the inventory (objects.inv) fetch, so the links were broken everywhere.

Result: mkdocs build is warning-free.