### PR TITLE
fix(ci): prevent dependabot pip ecosystem from bumping pyproject.toml deps without uv.lock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,11 @@ updates:
         patterns:
           - "*"
     versioning-strategy: increase
+    # pip also parses pyproject.toml's PEP-621 deps, but has no concept of
+    # uv.lock, so it would bump those without re-locking. Restrict it to the
+    # uv pin in requirements.txt; the uv ecosystem block below owns the rest.
+    allow:
+      - dependency-name: "uv"
 
   - package-ecosystem: "uv" # project deps (pyproject.toml + uv.lock)
     directory: "/"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install uv
         run: pip install --require-hashes -r requirements.txt
 
+      - name: Check uv.lock is up to date
+        run: uv lock --check
+
       - name: Install dependencies
         run: uv sync --group lint --group docs
 


### PR DESCRIPTION
### Changes
- Restrict the `pip` ecosystem to only the `uv` package (`allow: dependency-name: uv`), so it stops also bumping `pyproject.toml`'s PEP-621 deps without touching `uv.lock`. The dedicated `uv` ecosystem block already handles `pyproject.toml` + `uv.lock` together correctly.
- Add a `uv lock --check` CI step so any future `uv.lock`/`pyproject.toml` drift fails the `lint` job loudly instead of landing on `main` silently.

### Why
PR #281 came from the `pip` ecosystem block, which also parses `pyproject.toml`'s PEP-621 dependencies but has no concept of `uv.lock`. It bumped `cryptography`, `pytz`, `ruff`, `mkdocstrings`, and `pymdown-extensions` in `pyproject.toml` without re-locking, leaving `uv.lock` stale until manually fixed in #286.

Note: the `uv lock --check` step will fail on this PR until #286 (syncing `uv.lock`) merges into `main` first — that's expected, not a regression here.
